### PR TITLE
Middleware for anonymous user

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ AUTHBROKER_URL = 'speak-to-webops-team-for-access'
 AUTHBROKER_CLIENT_ID = 'speak-to-webops-team-for-access'
 AUTHBROKER_CLIENT_SECRET = 'speak-to-webops-team-for-access'
 AUTHBROKER_STAFF_SSO_SCOPE = 'any-additional-scope-values'
+AUTHBROKER_ANONYMOUS_PATHS = (Tuple/list of paths that should be unprotected)
 ```
 
 Add the `'authbroker_client.backends.AuthbrokerBackend'` authentication backend, e.g:

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -13,8 +13,6 @@ class ProtectAllViewsMiddleware:
         )
 
     def __call__(self, request):
-        print("hello")
-        print("request.path", request.path)
         if (
             request.path not in self.anonymous_paths and
             resolve(request.path).app_name != 'authbroker_client' and not

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -14,9 +14,9 @@ class ProtectAllViewsMiddleware:
 
     def __call__(self, request):
         if (
-            request.path not in self.anonymous_paths and 
-            resolve(request.path).app_name != 'authbroker_client' and not 
-            request.user.is_authenticated
+                request.path not in self.anonymous_paths and
+                resolve(request.path).app_name != 'authbroker_client' and not
+                request.user.is_authenticated
         ):
             return redirect('authbroker_client:login')
 

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -13,7 +13,7 @@ class ProtectAllViewsMiddleware:
         )
 
     def __call__(self, request):
-        if (
+        if (  #noqa W504
             request.path not in self.anonymous_paths and
             resolve(request.path).app_name != 'authbroker_client' and not
             request.user.is_authenticated

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -13,8 +13,9 @@ class ProtectAllViewsMiddleware:
         )
 
     def __call__(self, request):
-        if (  #noqa W504
-            request.path not in self.anonymous_paths and
+        if (
+            request.path not in
+            self.anonymous_paths and
             resolve(request.path).app_name != 'authbroker_client' and not
             request.user.is_authenticated
         ):

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -13,8 +13,7 @@ class ProtectAllViewsMiddleware:
         )
 
     def __call__(self, request):
-        if (
-            request.path not in
+        if (request.path not in
             self.anonymous_paths and
             resolve(request.path).app_name != 'authbroker_client' and not
             request.user.is_authenticated

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -12,9 +12,9 @@ class ProtectAllViewsMiddleware:
             (),
         )
 
-    def __call__(self, request):  # noqa W504
+    def __call__(self, request):
         if (
-            request.path not in self.anonymous_paths and
+            request.path not in self.anonymous_paths and  # noqa W504
             resolve(request.path).app_name != 'authbroker_client' and not
             request.user.is_authenticated
         ):

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -14,7 +14,8 @@ class ProtectAllViewsMiddleware:
 
     def __call__(self, request):
         if (
-                request.path not in self.anonymous_paths and
+                request.path not in
+                self.anonymous_paths and
                 resolve(request.path).app_name != 'authbroker_client' and not
                 request.user.is_authenticated
         ):

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -12,10 +12,9 @@ class ProtectAllViewsMiddleware:
             (),
         )
 
-    def __call__(self, request):  #noqa W504
+    def __call__(self, request):  # noqa W504
         if (
-            request.path not in
-            self.anonymous_paths and
+            request.path not in self.anonymous_paths and
             resolve(request.path).app_name != 'authbroker_client' and not
             request.user.is_authenticated
         ):

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -13,14 +13,15 @@ class ProtectAllViewsMiddleware:
         )
 
     def __call__(self, request):
+        print("hello")
+        print("request.path", request.path)
+        assert False
         if (
-                request.path not in
-                self.anonymous_paths and
-                resolve(request.path).app_name != 'authbroker_client' and not
-                request.user.is_authenticated
+            str(resolve(request.path)) not in self.anonymous_paths and
+            resolve(request.path).app_name != 'authbroker_client' and not
+            request.user.is_authenticated
         ):
             return redirect('authbroker_client:login')
 
         response = self.get_response(request)
-
         return response

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -15,9 +15,8 @@ class ProtectAllViewsMiddleware:
     def __call__(self, request):
         print("hello")
         print("request.path", request.path)
-        assert False
         if (
-            str(resolve(request.path)) not in self.anonymous_paths and
+            request.path not in self.anonymous_paths and
             resolve(request.path).app_name != 'authbroker_client' and not
             request.user.is_authenticated
         ):

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -12,8 +12,9 @@ class ProtectAllViewsMiddleware:
             (),
         )
 
-    def __call__(self, request):
-        if (request.path not in
+    def __call__(self, request):  #noqa W504
+        if (
+            request.path not in
             self.anonymous_paths and
             resolve(request.path).app_name != 'authbroker_client' and not
             request.user.is_authenticated

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import resolve
 
@@ -5,10 +6,18 @@ from django.urls import resolve
 class ProtectAllViewsMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
+        self.anonymous_paths = getattr(
+            settings,
+            'AUTHBROKER_ANONYMOUS_PATHS',
+            (),
+        )
 
     def __call__(self, request):
-
-        if resolve(request.path).app_name != 'authbroker_client' and not request.user.is_authenticated:
+        if (
+            request.path not in self.anonymous_paths and 
+            resolve(request.path).app_name != 'authbroker_client' and not 
+            request.user.is_authenticated
+        ):
             return redirect('authbroker_client:login')
 
         response = self.get_response(request)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -11,7 +11,7 @@ from authbroker_client.middleware import ProtectAllViewsMiddleware
 
 
 def get_response_fake(request):
-    return True
+    return "the-public-view"
 
 
 @pytest.mark.django_db
@@ -34,7 +34,7 @@ class AnonymousUserAccessibilityTests(TestCase):
     @mock.patch('authbroker_client.middleware.redirect')
     def test_anonymous_path(self, redirect, settings):
         middleware = ProtectAllViewsMiddleware(get_response=get_response_fake)
+        response = middleware(request=self.request)
 
-        outcome = middleware(request=self.request)
         assert not redirect.called
-        assert outcome
+        assert response == "the-public-view"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -9,15 +9,6 @@ from django.test.client import RequestFactory
 from authbroker_client.middleware import ProtectAllViewsMiddleware
 
 
-class resolve_mock():
-    def resolve(self):
-        return "url_name"
-
-    @property
-    def app_name(self):
-        return "app_name"
-
-
 def get_response_fake(request):
     return True
 
@@ -28,9 +19,8 @@ class AnonymousUserAccessibilityTests(TestCase):
         factory = RequestFactory()
         self.request = factory.get('/')
         self.request.user = AnonymousUser()
-        self.app_name = 'test'
 
-    @mock.patch('authbroker_client.middleware.settings', AUTHBROKER_ANONYMOUS_PATHS='')
+    @mock.patch('authbroker_client.middleware.settings', AUTHBROKER_ANONYMOUS_PATHS=())
     @mock.patch('authbroker_client.middleware.redirect')
     def test_no_anonymous_paths(self, redirect, settings):
         middleware = ProtectAllViewsMiddleware(get_response=get_response_fake)
@@ -38,13 +28,12 @@ class AnonymousUserAccessibilityTests(TestCase):
         middleware(request=self.request)
         redirect.assert_called_once_with("authbroker_client:login")
 
-    @mock.patch('authbroker_client.middleware.settings', AUTHBROKER_ANONYMOUS_PATHS="url_name")
+    @mock.patch('authbroker_client.middleware.settings', AUTHBROKER_ANONYMOUS_PATHS=("/", ))
     @mock.patch('authbroker_client.middleware.redirect')
-    @mock.patch('authbroker_client.middleware.resolve')
-    def test_anonymous_path(self, resolve, redirect, settings):
-        resolve.return_value = resolve_mock.resolve(self.app_name)
+    def test_anonymous_path(self, redirect, settings):
         middleware = ProtectAllViewsMiddleware(get_response=get_response_fake)
 
         outcome = middleware(request=self.request)
+        assert not redirect.called
         assert outcome
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,50 @@
+from unittest import mock
+
+import pytest
+
+from django.contrib.auth.models import AnonymousUser, User
+from django.test import TestCase, Client
+from django.test.client import RequestFactory
+
+from authbroker_client.middleware import ProtectAllViewsMiddleware
+
+
+class resolve_mock():
+    def resolve(self):
+        return "url_name"
+
+    @property
+    def app_name(self):
+        return "app_name"
+
+
+def get_response_fake(request):
+    return True
+
+
+@pytest.mark.django_db
+class AnonymousUserAccessibilityTests(TestCase):
+    def setUp(self):
+        factory = RequestFactory()
+        self.request = factory.get('/')
+        self.request.user = AnonymousUser()
+        self.app_name = 'test'
+
+    @mock.patch('authbroker_client.middleware.settings', AUTHBROKER_ANONYMOUS_PATHS='')
+    @mock.patch('authbroker_client.middleware.redirect')
+    def test_no_anonymous_paths(self, redirect, settings):
+        middleware = ProtectAllViewsMiddleware(get_response=get_response_fake)
+
+        middleware(request=self.request)
+        redirect.assert_called_once_with("authbroker_client:login")
+
+    @mock.patch('authbroker_client.middleware.settings', AUTHBROKER_ANONYMOUS_PATHS="url_name")
+    @mock.patch('authbroker_client.middleware.redirect')
+    @mock.patch('authbroker_client.middleware.resolve')
+    def test_anonymous_path(self, resolve, redirect, settings):
+        resolve.return_value = resolve_mock.resolve(self.app_name)
+        middleware = ProtectAllViewsMiddleware(get_response=get_response_fake)
+
+        outcome = middleware(request=self.request)
+        assert outcome
+

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -4,7 +4,7 @@ import pytest
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
-from django.test.client import RequestFactory, Client
+from django.test.client import RequestFactory
 from django.urls import reverse
 
 from authbroker_client.middleware import ProtectAllViewsMiddleware

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -2,8 +2,8 @@ from unittest import mock
 
 import pytest
 
-from django.contrib.auth.models import AnonymousUser, User
-from django.test import TestCase, Client
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase
 from django.test.client import RequestFactory
 
 from authbroker_client.middleware import ProtectAllViewsMiddleware
@@ -36,4 +36,3 @@ class AnonymousUserAccessibilityTests(TestCase):
         outcome = middleware(request=self.request)
         assert not redirect.called
         assert outcome
-

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -48,11 +48,3 @@ def test_callback_view_token(mocked_get_client, rf):
     request.GET = {'code': 'foo'}
     response = AuthCallbackView.as_view()(request)
     assert response.status_code == 302
-
-# def test_anonymous_path_view(client):
-#
-#     url = reverse('authbroker:login')
-#     response = client.get(url)
-#     assert response.status_code == 302
-#     assert AUTHORISATION_URL in response.url
-#     assert 'code=someCode' not in response.url

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -48,3 +48,11 @@ def test_callback_view_token(mocked_get_client, rf):
     request.GET = {'code': 'foo'}
     response = AuthCallbackView.as_view()(request)
     assert response.status_code == 302
+
+# def test_anonymous_path_view(client):
+#
+#     url = reverse('authbroker:login')
+#     response = client.get(url)
+#     assert response.status_code == 302
+#     assert AUTHORISATION_URL in response.url
+#     assert 'code=someCode' not in response.url


### PR DESCRIPTION
Allow the definition of paths which will not be not be checked by SSO middleware. For example, a Pingdom endpoint.