### PR TITLE
Add ability to mark a url/view as anonymous

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ AUTHBROKER_CLIENT_ID = 'speak-to-webops-team-for-access'
 AUTHBROKER_CLIENT_SECRET = 'speak-to-webops-team-for-access'
 AUTHBROKER_STAFF_SSO_SCOPE = 'any-additional-scope-values'
 AUTHBROKER_ANONYMOUS_PATHS = (Tuple/list of paths that should be unprotected)
+AUTHBROKER_ANONYMOUS_URL_NAMES = (list of url names that should be unprotected)
 ```
 
 Add the `'authbroker_client.backends.AuthbrokerBackend'` authentication backend, e.g:
@@ -181,6 +182,12 @@ In order to allow anonymous access to a page on a site protected using this clie
 ```
 AUTHBROKER_ANONYMOUS_PATHS = ('anonymous/path',)
 ```
+
+Alternatively, you can use the `AUTHBROKER_ANONYMOUS_URL_NAMES` setting to specify a list of url names.
+```
+AUTHBROKER_ANONYMOUS_URL_NAMES = ('url-name',)
+```
+
 ## Use with UKTrade mock-sso package
 
 It is possible to configure this package to work with the [mock-sso service](https://github.com/uktrade/mock-sso).

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -33,7 +33,7 @@ class ProtectAllViewsMiddleware:
         return redirect(f"{redirect_url}?{querystring}")
 
     def __call__(self, request):
-        if not request.user.is_authenticated:  # noqa: W503
+        if not request.user.is_authenticated:
             resolved_path = resolve(request.path)
             is_anonymous_path = request.path in self.anonymous_paths
             is_anonymous_url_name = resolved_path.url_name in self.anonymous_url_names
@@ -42,7 +42,7 @@ class ProtectAllViewsMiddleware:
             if (
                 not is_anonymous_path
                 and not is_anonymous_url_name
-                and not is_authbroker_client_path  # noqa: W503
+                and not is_authbroker_client_path
             ):
                 return self.get_redirect_url(request)
 

--- a/authbroker_client/middleware.py
+++ b/authbroker_client/middleware.py
@@ -11,7 +11,12 @@ class ProtectAllViewsMiddleware:
         self.get_response = get_response
         self.anonymous_paths = getattr(
             settings,
-            'AUTHBROKER_ANONYMOUS_PATHS',
+            "AUTHBROKER_ANONYMOUS_PATHS",
+            (),
+        )
+        self.anonymous_url_names = getattr(
+            settings,
+            "AUTHBROKER_ANONYMOUS_URL_NAMES",
             (),
         )
 
@@ -23,17 +28,23 @@ class ProtectAllViewsMiddleware:
 
         querystring = urlencode(params)
 
-        redirect_url = reverse('authbroker_client:login')
+        redirect_url = reverse("authbroker_client:login")
 
         return redirect(f"{redirect_url}?{querystring}")
 
     def __call__(self, request):
-        if (
-            request.path not in self.anonymous_paths
-            and resolve(request.path).app_name != "authbroker_client"  # noqa: W503
-            and not request.user.is_authenticated  # noqa: W503
-        ):
-            return self.get_redirect_url(request)
+        if not request.user.is_authenticated:  # noqa: W503
+            resolved_path = resolve(request.path)
+            is_anonymous_path = request.path in self.anonymous_paths
+            is_anonymous_url_name = resolved_path.url_name in self.anonymous_url_names
+            is_authbroker_client_path = resolved_path.app_name == "authbroker_client"
+
+            if (
+                not is_anonymous_path
+                and not is_anonymous_url_name
+                and not is_authbroker_client_path  # noqa: W503
+            ):
+                return self.get_redirect_url(request)
 
         response = self.get_response(request)
         return response

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 120
 exclude = .git,*/migrations/*,*/static/CACHE/*,node_modules,*settings*,manage.py,wsgi.py
-ignore = D203, D100, D101, D102, D103, D104, D105, D106, D107, D401
+ignore = D203, D100, D101, D102, D103, D104, D105, D106, D107, D401, W503
 max-complexity = 7
 application-import-names = authbroker_client
 import_order_style = smarkets

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,12 +1,10 @@
 from unittest import mock
 
 import pytest
-
+from authbroker_client.middleware import ProtectAllViewsMiddleware
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 from django.test.client import RequestFactory
-
-from authbroker_client.middleware import ProtectAllViewsMiddleware
 
 
 def get_response_fake(request):
@@ -20,18 +18,30 @@ class ProtectAllViewsMiddelwareTestCase(TestCase):
         self.request = factory.get("/")
         self.request.user = AnonymousUser()
 
-    @mock.patch('authbroker_client.middleware.settings', AUTHBROKER_ANONYMOUS_PATHS=())
-    def test_no_anonymous_paths(self, settings):
+    def test_no_settings(self):
         middleware = ProtectAllViewsMiddleware(get_response=get_response_fake)
-
         response = middleware(request=self.request)
-        assert response.status_code == 302
 
+        assert response.status_code == 302
         assert response.url == "/auth/login/?next=%2F"
 
-    @mock.patch('authbroker_client.middleware.settings', AUTHBROKER_ANONYMOUS_PATHS=("/",))
-    @mock.patch('authbroker_client.middleware.redirect')
+    @mock.patch(
+        "authbroker_client.middleware.settings", AUTHBROKER_ANONYMOUS_PATHS=("/",)
+    )
+    @mock.patch("authbroker_client.middleware.redirect")
     def test_anonymous_path(self, redirect, settings):
+        middleware = ProtectAllViewsMiddleware(get_response=get_response_fake)
+        response = middleware(request=self.request)
+
+        assert not redirect.called
+        assert response == "the-public-view"
+
+    @mock.patch(
+        "authbroker_client.middleware.settings",
+        AUTHBROKER_ANONYMOUS_URL_NAMES=("home",),
+    )
+    @mock.patch("authbroker_client.middleware.redirect")
+    def test_anonymous_path_name(self, redirect, settings):
         middleware = ProtectAllViewsMiddleware(get_response=get_response_fake)
         response = middleware(request=self.request)
 


### PR DESCRIPTION
This PR will allow apps to mark a whole view as anonymous. This is beneficial for things like URL endpoints that contain variables in the path.