### PR TITLE
feat: add AUTHBROKER_INTERNAL_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ MIDDLEWARE = [
 ]
 ```
 
+For local development with https://github.com/uktrade/mock-sso, where it runs under a port 8001 as a Docker service called `sso` for example, add the following to your settings file.
+
+```
+AUTHBROKER_INTERNAL_URL = 'http://sso:8001'
+```
+
+For remote deployments, AUTHBROKER_INTERNAL_URL can be ommitted or equal to AUTHBROKER_URL.
+
+
 ## Change the default user id field
 
 Staff-sso maintains two unique user ids for each user: the `email_user_id` field, which is in an email format [NOTE: it is purely a unique id, not a valid email address] and the `user_id` field, which is a GUID.  By default (from version 3.0.0 onwards) django-staff-sso-client identifies users based on the `email_user_id` field.  This is the preferred option for most cases.  If however, you need to use the `user_id` field, then add this to your settings.py file:

--- a/authbroker_client/utils.py
+++ b/authbroker_client/utils.py
@@ -9,10 +9,14 @@ from requests_oauthlib import OAuth2Session
 
 
 TOKEN_SESSION_KEY = '_authbroker_token'
-PROFILE_URL = urljoin(settings.AUTHBROKER_URL, '/api/v1/user/me/')
-INTROSPECT_URL = urljoin(settings.AUTHBROKER_URL, 'o/introspect/')
-TOKEN_URL = urljoin(settings.AUTHBROKER_URL, '/o/token/')
+
 AUTHORISATION_URL = urljoin(settings.AUTHBROKER_URL, '/o/authorize/')
+
+AUTHBROKER_URL = getattr(settings, 'AUTHBROKER_INTERNAL_URL', settings.AUTHBROKER_URL)
+PROFILE_URL = urljoin(AUTHBROKER_URL, '/api/v1/user/me/')
+INTROSPECT_URL = urljoin(AUTHBROKER_URL, 'o/introspect/')
+TOKEN_URL = urljoin(AUTHBROKER_URL, '/o/token/')
+
 TOKEN_CHECK_PERIOD_SECONDS = 60
 
 


### PR DESCRIPTION
This adds the setting AUTHBROKER_INTERNAL_URL. This is the URL that the client uses internally to fetch and check tokens, i.e. not exposed to the user.

This is primarily for easier local development with https://github.com/uktrade/mock-sso using Docker compose. While working with mock-sso is possible without this change, having the internal/external URLs the same means you have to have a /etc/hosts host pointing to localhost that matches the mock-sso service name in the compose file. Having them separate means you don't have to make any /etc/hosts changes.

This should also ease future changes to the client where communication with Staff SSO on the server side is _not_ over the public internet.