### PR TITLE
chore: update version from 4.3.0 to 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.4.0](https://pypi.org/project/django-staff-sso-client/4.4.0/) (2025-03-05)
+
+- Add the optional AUTHBROKER_INTERNAL_URL setting.
+  
+  This allows the external (internet/user-facing) and internal (Django application->SSO) URLs to be different.
+
 ## [4.3.0](https://pypi.org/project/django-staff-sso-client/4.3.0/) (2024-06-11)
 
 - Added support for Django 5

--- a/authbroker_client/version.py
+++ b/authbroker_client/version.py
@@ -1,2 +1,2 @@
 # The version of the package
-__version__ = "4.3.0"
+__version__ = "4.4.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,4 +3,4 @@ from authbroker_client.version import __version__
 
 def test_version():
     # Tests the version of the package
-    assert __version__ == "4.3.0"
+    assert __version__ == "4.4.0"


### PR DESCRIPTION
Going for a minor version update because the only change is the addition of a backwards-compatible option.