### PR TITLE
feat: Django 6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,26 @@ jobs:
             make pytest
             codecov
 
+  test_django6:
+    docker:
+      - image: cimg/python:3.12.3
+    steps:
+      - checkout
+      - run:
+          name: Create virtualenv and install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install --upgrade --no-cache-dir pip
+            make test_requirements
+            pip install --no-cache-dir django==6.0.3
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            make pytest
+            codecov
+
   flake8:
     docker:
       - image: cimg/python:3.13.7
@@ -72,6 +92,7 @@ workflows:
     jobs:
       - test_django4
       - test_django5
+      - test_django6
       - flake8
       - publish_to_pypi:
           requires:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/uktrade/github-standards
-    rev: v1.2.1 # This should be the latest github released tag, see https://github.com/uktrade/github-standards/releases for the latest tag
+    rev: v1.3.1 # This should be the latest github released tag, see https://github.com/uktrade/github-standards/releases for the latest tag
     hooks:
       - id: validate-security-scan
         verbose: false # This is helpful for debugging initial setup, it can be removed when the hooks are verified as working in your repository

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
-        'Django>=4.2.10,<6.0',
+        'Django>=4.2.10,<7.0',
         'requests_oauthlib',
         'django-log-formatter-asim~=1.1'
     ],


### PR DESCRIPTION
# Description

This updates the maximum version of Django from 5 to 6. Along the way also increased the pre-commit hook version that does secret scanning.

## Contributors

N/A

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Tested by running the existing tests against Django 6 in CircleCI
Briefly tested locally with https://github.com/uktrade/mock-sso in a new Django 6 project (pulling from the branch in this PR)

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present