### PR TITLE
feat: Allow for setting variables via Django settings to enable use of other IdPs

### DIFF
--- a/authbroker_client/utils.py
+++ b/authbroker_client/utils.py
@@ -8,14 +8,19 @@ from django.urls import reverse
 from requests_oauthlib import OAuth2Session
 
 
-TOKEN_SESSION_KEY = '_authbroker_token'
+TOKEN_SESSION_KEY = getattr(settings, "AUTHBROKER_TOKEN_SESSION_KEY", "_authbroker_token")
 
-AUTHORISATION_URL = urljoin(settings.AUTHBROKER_URL, '/o/authorize/')
+AUTHORISATION_PATH = getattr(settings, "AUTHBROKER_AUTH_PATH", "/o/authorize/")
+AUTHORISATION_URL = urljoin(settings.AUTHBROKER_URL, AUTHORISATION_PATH)
 
 AUTHBROKER_URL = getattr(settings, 'AUTHBROKER_INTERNAL_URL', settings.AUTHBROKER_URL)
-PROFILE_URL = urljoin(AUTHBROKER_URL, '/api/v1/user/me/')
-INTROSPECT_URL = urljoin(AUTHBROKER_URL, 'o/introspect/')
-TOKEN_URL = urljoin(AUTHBROKER_URL, '/o/token/')
+PROFILE_URL = getattr(settings, "AUTHBROKER_PROFILE_URL", urljoin(AUTHBROKER_URL, "/api/v1/user/me/"))
+
+INTROSPECT_PATH = getattr(settings, "AUTHBROKER_INTROSPECT_PATH", "/o/introspect/")
+INTROSPECT_URL = urljoin(AUTHBROKER_URL, INTROSPECT_PATH)
+
+TOKEN_PATH = getattr(settings, "AUTHBROKER_TOKEN_PATH", "/o/token/")
+TOKEN_URL = urljoin(AUTHBROKER_URL, TOKEN_PATH)
 
 TOKEN_CHECK_PERIOD_SECONDS = 60
 


### PR DESCRIPTION
### Description

This PR documents some of the changes that need implementing if we want to genericise this SSO client to support additional identity providers.

Essentially, it allows for passing in additional Django settings for the following:

- `AUTHBROKER_AUTH_PATH` - This is the IdP's login path, e.g. for GitHub OAuth `/login/oauth/authorize`. Used for building the `AUTHORISATION_URL`
- `TOKEN_PATH` - Path for fetching the access token once the user logs in, e.g. for GitHub OAuth `/login/oauth/access_token`. Used for building the `TOKEN_URL`
- `TOKEN_SESSION_KEY` - Name of the field that contains the access token once the token is fetched, e.g. for GitHub OAuth `access_token`
- `INTROSPECT_PATH` - Path to the IdP's token introspection endpoint. Used for building the `INTROSPECT_URL` (currently not used?)
- `PROFILE_URL` - URL to the IdP's user profile endpoint, e.g. for GitHub `https://api.github.com/user`

### Rationale

This work was part of an investigation to see if this SSO client could be used in place of other SSO clients that are currently being used in DBT services. The reason this client was chosen was due to it's existing support for ASIM formatted logging.

### Conclusion

Outside of the Staff SSO IdP, the most prolific IdP that DBT services need to talk to seems to be GOV.UK One Login. Unfortunately, since GOV.UK One Login doesn't use the client secret authentication method and instead uses private key JWT authentication (see [here](https://docs.sign-in.service.gov.uk/how-gov-uk-one-login-works/#how-gov-uk-one-login-works) for more details) there would need to be significantly more work done here to support both authentication methods and we have chosen to instead instrument the logging for other clients rather than continue adding support to this client.