### PR TITLE
Handle concurrent auth flows 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.3.0](https://pypi.org/project/django-staff-sso-client/5.3.0/) (2026-07-07)
+
+Add support for multiple concurrent auhentication flows. See the README for more information.
+
+Minor funciontality change: if the `/auth/callback/` is hit without a valie `authcode`, instead of emitting a 400/Bad Request, the user is instead redirected back to `/auth/login/` to restart the auth flow.
+
+See [README[(README.md) for more information. 
+
 ## [5.2.1](https://pypi.org/project/django-staff-sso-client/5.2.1/) (2026-04-25)
 [Full Changelog](https://github.com/uktrade/django-staff-sso-client/pull/60/files)
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ Alternatively, you can use the `AUTHBROKER_ANONYMOUS_URL_NAMES` setting to speci
 AUTHBROKER_ANONYMOUS_URL_NAMES = ('url-name',)
 ```
 
+## Multiple concurrent auth flows and cache storage
+
+This new logic, which requies an opt-in by setting `AUTHBROKER_USE_CACHE_STATE_STORE` in your project's settings file, attempts to resolve potential errors caused by multiple concurrent auth flows.  Two potential failure modes are:
+
+1. The state key is clobbered by concurrent auth flows. 
+2. In `/auth/callback/`, the `django.contrib.auth.login()` funcion cycles the session idy to prevent session fixation attacks. If another flow sends the old session id via a cookie, it may result in an empty session and missing state key.
+
+To remediate this the state value is incorporated into the key (e.g. `f'_oauth_{state}'`) and the state value is stored in the cache, instead of in session. Also, if `request.user.is_authenticated` is True, the `/auth/callback/` process short circuits the Oauth2 token exchange process.
+
+Apps that  use the cache need to use a cache backend that persists across processes such as the `RedisCache`. The default `LocMemCache`, which should only be used for local development, will break your SSO integration.
+
 ## Use with UKTrade mock-sso package
 
 It is possible to configure this package to work with the [mock-sso service](https://github.com/uktrade/mock-sso).

--- a/authbroker_client/state.py
+++ b/authbroker_client/state.py
@@ -1,0 +1,66 @@
+import logging
+
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.core.cache import caches
+
+from authbroker_client.utils import TOKEN_SESSION_KEY
+
+logger = logging.getLogger(__name__)
+
+OAUTH_STATE_SESSION_KEY = TOKEN_SESSION_KEY + "_oauth_state"
+REDIRECT_SESSION_FIELD_NAME = f"_oauth2_{REDIRECT_FIELD_NAME}"
+
+CACHE_STATE_KEY_PREFIX = "_authbroker_oauth_state"
+DEFAULT_STATE_TTL_SECONDS = 600
+
+
+def use_cache_state_store():
+    return getattr(settings, "AUTHBROKER_USE_CACHE_STATE_STORE", False)
+
+
+def _cache():
+    alias = getattr(settings, "AUTHBROKER_STATE_CACHE_ALIAS", "default")
+    return caches[alias]
+
+
+def _cache_key(state):
+    return f"{CACHE_STATE_KEY_PREFIX}_{state}"
+
+
+def _state_ttl():
+    return getattr(
+        settings, "AUTHBROKER_STATE_TTL_SECONDS", DEFAULT_STATE_TTL_SECONDS
+    )
+
+
+def store_state(request, state, next_url):
+    """Persist the `state` value along with the redirect url."""
+    if use_cache_state_store():
+        _cache().set(
+            _cache_key(state),
+            {"next_url": next_url},
+            timeout=_state_ttl(),
+        )
+        return
+
+    request.session[REDIRECT_SESSION_FIELD_NAME] = next_url
+    request.session[OAUTH_STATE_SESSION_KEY] = state
+    # Force the session to persist now.
+    request.session.save()
+
+
+def pop_state(request, state):
+
+    if use_cache_state_store():
+        if not state:
+            return None
+
+        key = _cache_key(state)
+        data = _cache().get(key)
+        if data is not None:
+            _cache().delete(key)
+        return data
+
+    return request.session.pop(OAUTH_STATE_SESSION_KEY, None)
+ 

--- a/authbroker_client/version.py
+++ b/authbroker_client/version.py
@@ -1,2 +1,2 @@
 # The version of the package
-__version__ = "5.2.1"
+__version__ = "5.3.0"

--- a/authbroker_client/views.py
+++ b/authbroker_client/views.py
@@ -12,16 +12,19 @@ from authbroker_client.utils import (
     TOKEN_URL,
     TOKEN_SESSION_KEY,
 )
+from authbroker_client.state import (
+    store_state,
+    pop_state,
+    use_cache_state_store,
+    REDIRECT_SESSION_FIELD_NAME,
+)
 
 logger = logging.getLogger(__name__)
-
-REDIRECT_SESSION_FIELD_NAME = f"_oauth2_{REDIRECT_FIELD_NAME}"
-OAUTH_STATE_SESSION_KEY = TOKEN_SESSION_KEY + "_oauth_state"
 
 
 def _request_fingerprint(request):
     """Fields that let us correlate the login leg with the callback leg and
-    diagnose *why* the session state is missing. """
+    diagnose why the session state is missing. """
     return {
         "session_key": request.session.session_key,
         "cookie_present": settings.SESSION_COOKIE_NAME in request.COOKIES,
@@ -63,18 +66,15 @@ class AuthView(RedirectView):
             AUTHORISATION_URL, **auth_url_extra_kwargs
         )
 
-        self.request.session[REDIRECT_SESSION_FIELD_NAME] = get_next_url(self.request)
-        self.request.session[OAUTH_STATE_SESSION_KEY] = state
-
-        # Force the session to persist now         
         was_new = self.request.session.session_key is None
-        self.request.session.save()
+        store_state(self.request, state, get_next_url(self.request))
 
         logger.info(
             "oauth login: state issued, redirecting to SSO",
             extra={
                 "oauth_state": state,
                 "session_was_new": was_new,
+                "state_store": "cache" if use_cache_state_store() else "session",
                 **_request_fingerprint(self.request),
             },
         )
@@ -82,15 +82,26 @@ class AuthView(RedirectView):
 
 
 class AuthCallbackView(View):
+
     def get(self, request, *args, **kwargs):
+        # Short circuit the callback flow if the user is already authenticated
+        if request.user.is_authenticated:
+            next_url = get_next_url(request) or getattr(
+                settings, "LOGIN_REDIRECT_URL", "/"
+            )
+            logger.info(
+                "oauth callback: user already authenticated, short-circuiting",
+                extra={"state_store": "cache", **_request_fingerprint(request)},
+            )
+            return redirect(next_url)
+
         returned_state = request.GET.get("state")
         auth_code = request.GET.get("code", None)
-        session_state = request.session.get(OAUTH_STATE_SESSION_KEY, None)
 
         meta = {
             "oauth_state_in_query": returned_state,
-            "oauth_state_in_session": session_state,
             "code_present": bool(auth_code),
+            "state_store": "cache",
             **_request_fingerprint(request),
         }
 
@@ -98,13 +109,15 @@ class AuthCallbackView(View):
             logger.warning("oauth callback: missing auth code (400)", extra=meta)
             return HttpResponseBadRequest()
 
-        if not session_state:
-            logger.error("oauth callback: state missing from session (500)", extra=meta)
-            return HttpResponseServerError()
+        state_data = pop_state(request, returned_state)
 
-        # NOTE: logging for now, but the request should fail is there's a state mismatch.
-        if returned_state and returned_state != session_state:
-            logger.error("oauth callback: query/session state mismatch", extra=meta)
+        if state_data is None:
+            # Unknown or already consumed state. Redirect the user back through the auth flow.
+            logger.warning(
+                "oauth callback: state not found in store, restarting auth flow",
+                extra=meta,
+            )
+            return redirect("authbroker_client:login")
 
         try:
             token = get_client(request).fetch_token(
@@ -112,11 +125,14 @@ class AuthCallbackView(View):
                 client_secret=settings.AUTHBROKER_CLIENT_SECRET,
                 code=auth_code,
             )
+
             request.session[TOKEN_SESSION_KEY] = dict(token)
-            del request.session[OAUTH_STATE_SESSION_KEY]
+
             logger.info("oauth callback: token retrieved", extra=meta)
         except BaseException:
-            logger.exception("oauth callback: failed to retrieve access token", extra=meta)
+            logger.exception(
+                "oauth callback: failed to retrieve access token", extra=meta
+            )
 
         user = authenticate(request)
         if user is not None:
@@ -124,5 +140,7 @@ class AuthCallbackView(View):
         else:
             logger.warning("oauth callback: authenticate() returned no user", extra=meta)
 
-        next_url = get_next_url(request) or getattr(settings, "LOGIN_REDIRECT_URL", "/")
+        next_url = state_data.get("next_url") or getattr(
+            settings, "LOGIN_REDIRECT_URL", "/"
+        )
         return redirect(next_url)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,4 +3,4 @@ from authbroker_client.version import __version__
 
 def test_version():
     # Tests the version of the package
-    assert __version__ == "5.2.1"
+    assert __version__ == "5.3.0"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,22 +1,16 @@
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
-from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
 
 import pytest
 
 from authbroker_client.utils import AUTHORISATION_URL, TOKEN_SESSION_KEY
+from authbroker_client.state import OAUTH_STATE_SESSION_KEY
 from authbroker_client.views import AuthCallbackView, REDIRECT_SESSION_FIELD_NAME
 
-
-def _test_user():
-    return get_user_model().objects.create(
-        username="test",
-        email="test",
-        is_active=True, 
-    ) 
-    
 
 @pytest.mark.django_db
 def test_auth_view(client):
@@ -63,7 +57,7 @@ def test_callback_view_no_auth_state(client):
     """Redirect back to `/auth/login/` and restart the auth flow"""
     url = reverse('authbroker:callback')
     response = client.get(url, {'code': 'foo'})
-    assert response.status_code == 302 
+    assert response.status_code == 302
     assert response.url == reverse('authbroker:login')
 
 
@@ -80,7 +74,7 @@ def test_callback_view_token(mocked_get_client, rf):
     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
     url = reverse('authbroker:callback')
     request = rf.get(url)
-    request.user = AnonymousUser 
+    request.user = AnonymousUser
     request.session = StubSessionBackend({f'{TOKEN_SESSION_KEY}_oauth_state': 'state'})
     request.GET = {'code': 'foo'}
     response = AuthCallbackView.as_view()(request)
@@ -124,12 +118,16 @@ def test_callback_view_token_with_unsafe_next_url(mocked_get_client, rf):
 
 @pytest.mark.django_db
 @mock.patch('authbroker_client.views.get_client')
-def test_callback_user_already_authenticated(mocked_get_client, rf):
+def test_callback_user_already_authenticated(mocked_get_client, rf, django_user_model):
     """Short circuit the oauth processs if the user is already authenticated"""
     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
     url = reverse('authbroker:callback')
     request = rf.get(url)
-    request.user = _test_user() 
+    request.user = django_user_model.objects.create(
+        username="test",
+        email="test",
+        is_active=True,
+    )
     request.session = StubSessionBackend({
         f'{TOKEN_SESSION_KEY}_oauth_state': 'state',
         REDIRECT_SESSION_FIELD_NAME: 'https://danger.com/'
@@ -138,3 +136,99 @@ def test_callback_user_already_authenticated(mocked_get_client, rf):
     response = AuthCallbackView.as_view()(request)
     assert response.status_code == 302
     assert not mocked_get_client.called
+
+# Cache based tests
+
+def _state_key(state):
+    return f'_authbroker_oauth_state_{state}'
+
+
+@pytest.fixture
+def use_cache(settings):
+    settings.AUTHBROKER_USE_CACHE_STATE_STORE = True
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.mark.django_db
+def test_cache_auth_view_stores_state_in_cache_not_session(client, use_cache):
+    response = client.get(reverse('authbroker:login'))
+    assert response.status_code == 302
+
+    state = parse_qs(urlparse(response.url).query)['state'][0]
+    # State lives in the cache, keyed by its own value
+    assert cache.get(_state_key(state)) == {'next_url': None}
+    # ...and NOT in the session, so concurrent flows can't clobber it.
+    assert OAUTH_STATE_SESSION_KEY not in client.session
+
+
+@pytest.mark.django_db
+def test_cache_auth_view_stores_next_url_in_cache(client, use_cache):
+    url = reverse('authbroker:login') + '?next=/go-here/'
+    response = client.get(url)
+
+    state = parse_qs(urlparse(response.url).query)['state'][0]
+    assert cache.get(_state_key(state)) == {'next_url': '/go-here/'}
+
+
+@pytest.mark.django_db
+@mock.patch('authbroker_client.views.get_client')
+def test_cache_callback_valid_state(mocked_get_client, client, use_cache):
+    mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
+    cache.set(_state_key('state-A'), {'next_url': '/after/'}, 600)
+
+    response = client.get(
+        reverse('authbroker:callback'), {'code': 'foo', 'state': 'state-A'}
+    )
+
+    assert response.status_code == 302
+    assert response.url == '/after/'
+    # Single-use: the state is consumed on lookup.
+    assert cache.get(_state_key('state-A')) is None
+
+
+@pytest.mark.django_db
+def test_cache_callback_unknown_state_restarts_flow(client, use_cache):
+    response = client.get(
+        reverse('authbroker:callback'), {'code': 'foo', 'state': 'never-issued'}
+    )
+    assert response.status_code == 302
+    assert response.url == reverse('authbroker:login')
+
+
+@pytest.mark.django_db
+def test_cache_callback_no_code_is_400(client, use_cache):
+    response = client.get(reverse('authbroker:callback'))
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_cache_callback_short_circuits_when_authenticated(
+    client, django_user_model, use_cache
+):
+    user = django_user_model.objects.create(username='someone@example.com')
+    client.force_login(user)
+
+    response = client.get(
+        reverse('authbroker:callback'), {'code': 'foo', 'state': 'anything'}
+    )
+
+    assert response.status_code == 302
+    assert response.url != reverse('authbroker:login')
+
+
+@pytest.mark.django_db
+@mock.patch('authbroker_client.views.get_client')
+def test_cache_concurrent_flows_both_resolve(mocked_get_client, client, use_cache):
+    """Test multiple flows can run concurrently without clobbering the state key."""
+    mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
+    cache.set(_state_key('A'), {'next_url': '/a/'}, 600)
+    cache.set(_state_key('B'), {'next_url': '/b/'}, 600)
+
+    callback = reverse('authbroker:callback')
+    r1 = client.get(callback, {'code': 'c1', 'state': 'A'})
+    r2 = client.get(callback, {'code': 'c2', 'state': 'B'})
+
+    assert r1.url == '/a/'
+    assert r2.url == '/b/'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
 
 import pytest
@@ -7,6 +9,14 @@ import pytest
 from authbroker_client.utils import AUTHORISATION_URL, TOKEN_SESSION_KEY
 from authbroker_client.views import AuthCallbackView, REDIRECT_SESSION_FIELD_NAME
 
+
+def _test_user():
+    return get_user_model().objects.create(
+        username="test",
+        email="test",
+        is_active=True, 
+    ) 
+    
 
 @pytest.mark.django_db
 def test_auth_view(client):
@@ -50,9 +60,11 @@ def test_callback_view_no_auth_code(client):
 
 @pytest.mark.django_db
 def test_callback_view_no_auth_state(client):
+    """Redirect back to `/auth/login/` and restart the auth flow"""
     url = reverse('authbroker:callback')
     response = client.get(url, {'code': 'foo'})
-    assert response.status_code == 500
+    assert response.status_code == 302 
+    assert response.url == reverse('authbroker:login')
 
 
 class StubSessionBackend(dict):
@@ -68,6 +80,7 @@ def test_callback_view_token(mocked_get_client, rf):
     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
     url = reverse('authbroker:callback')
     request = rf.get(url)
+    request.user = AnonymousUser 
     request.session = StubSessionBackend({f'{TOKEN_SESSION_KEY}_oauth_state': 'state'})
     request.GET = {'code': 'foo'}
     response = AuthCallbackView.as_view()(request)
@@ -81,6 +94,7 @@ def test_callback_view_token_with_next_url(mocked_get_client, rf):
     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
     url = reverse('authbroker:callback')
     request = rf.get(url)
+    request.user = AnonymousUser
     request.session = StubSessionBackend({
         f'{TOKEN_SESSION_KEY}_oauth_state': 'state',
         REDIRECT_SESSION_FIELD_NAME: '/go-here-after-authenticating/'
@@ -97,6 +111,7 @@ def test_callback_view_token_with_unsafe_next_url(mocked_get_client, rf):
     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
     url = reverse('authbroker:callback')
     request = rf.get(url)
+    request.user = AnonymousUser
     request.session = StubSessionBackend({
         f'{TOKEN_SESSION_KEY}_oauth_state': 'state',
         REDIRECT_SESSION_FIELD_NAME: 'https://danger.com/'
@@ -105,3 +120,21 @@ def test_callback_view_token_with_unsafe_next_url(mocked_get_client, rf):
     response = AuthCallbackView.as_view()(request)
     assert response.status_code == 302
     assert response.url == '/'
+
+
+@pytest.mark.django_db
+@mock.patch('authbroker_client.views.get_client')
+def test_callback_user_already_authenticated(mocked_get_client, rf):
+    """Short circuit the oauth processs if the user is already authenticated"""
+    mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
+    url = reverse('authbroker:callback')
+    request = rf.get(url)
+    request.user = _test_user() 
+    request.session = StubSessionBackend({
+        f'{TOKEN_SESSION_KEY}_oauth_state': 'state',
+        REDIRECT_SESSION_FIELD_NAME: 'https://danger.com/'
+    })
+    request.GET = {'code': 'foo'}
+    response = AuthCallbackView.as_view()(request)
+    assert response.status_code == 302
+    assert not mocked_get_client.called


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

# Description

This PR attempts to fix a low rate (2-3%) of 500 errors seen on Digital Workspace and other services, which we believe is caused by the state key being clobbered by simultaneous auth flows.

Problem: 
The prior PR to add enhanced logging has revealed that we see a state mismatch and also a missing state session key for about 2-3% of requests to `/auth/callback/` 

Remediation:
* the state key  has the state value embedded in it to avoid collisions: f`'_oauth_state_{state}` 
* the state value is stored in django's cache system rather than in session. This should prevent a concurrency issue where one auth flow succeseds and calls `login(user)`, which cycles the `sessionid`.
* If the state key is incorrect or missing, we now send the user back to staff-sso instead of emitting a 500
* These changes are opt-in by setting `AUTHBROKER_USE_CACHE_STATE_STORE` in the app's settings. 

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present