### PR TITLE
fix: callback view expects state data dict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
       - id: run-security-scan
         verbose: false
         args: [--verbose]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8

--- a/authbroker_client/state.py
+++ b/authbroker_client/state.py
@@ -63,4 +63,3 @@ def pop_state(request, state):
         return data
 
     return request.session.pop(OAUTH_STATE_SESSION_KEY, None)
- 

--- a/authbroker_client/version.py
+++ b/authbroker_client/version.py
@@ -1,2 +1,2 @@
 # The version of the package
-__version__ = "5.3.0"
+__version__ = "5.3.1"

--- a/authbroker_client/views.py
+++ b/authbroker_client/views.py
@@ -51,7 +51,7 @@ def get_next_url(request):
 
 
 def get_next_url_from_state(
-    request: HttpRequest, 
+    request: HttpRequest,
     state_data: dict[str, str | None] | str
 ) -> str:
     if use_cache_state_store():

--- a/authbroker_client/views.py
+++ b/authbroker_client/views.py
@@ -2,7 +2,7 @@ import logging
 
 from django.views.generic.base import RedirectView, View
 from django.shortcuts import redirect
-from django.http import HttpResponseBadRequest, HttpResponseServerError
+from django.http import HttpResponseBadRequest, HttpRequest
 from django.conf import settings
 from django.contrib.auth import authenticate, login, REDIRECT_FIELD_NAME
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -48,6 +48,15 @@ def get_next_url(request):
     if next_url:
         logger.info("next_url rejected by allow-list", extra={"next_url": next_url})
     return None
+
+
+def get_next_url_from_state(
+    request: HttpRequest, 
+    state_data: dict[str, str | None] | str
+) -> str:
+    if use_cache_state_store():
+        return state_data.get("next_url")
+    return get_next_url(request)
 
 
 class AuthView(RedirectView):
@@ -140,6 +149,7 @@ class AuthCallbackView(View):
         else:
             logger.warning("oauth callback: authenticate() returned no user", extra=meta)
 
+        # next_url = get_next_url_from_state(request, state_data) or getattr(
         next_url = state_data.get("next_url") or getattr(
             settings, "LOGIN_REDIRECT_URL", "/"
         )

--- a/authbroker_client/views.py
+++ b/authbroker_client/views.py
@@ -149,8 +149,7 @@ class AuthCallbackView(View):
         else:
             logger.warning("oauth callback: authenticate() returned no user", extra=meta)
 
-        # next_url = get_next_url_from_state(request, state_data) or getattr(
-        next_url = state_data.get("next_url") or getattr(
+        next_url = get_next_url_from_state(request, state_data) or getattr(
             settings, "LOGIN_REDIRECT_URL", "/"
         )
         return redirect(next_url)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,4 +3,4 @@ from authbroker_client.version import __version__
 
 def test_version():
     # Tests the version of the package
-    assert __version__ == "5.3.0"
+    assert __version__ == "5.3.1"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -139,6 +139,7 @@ def test_callback_user_already_authenticated(mocked_get_client, rf, django_user_
 
 # Cache based tests
 
+
 def _state_key(state):
     return f'_authbroker_oauth_state_{state}'
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -99,22 +99,6 @@ def test_callback_view_token_with_next_url(mocked_get_client, rf):
     assert response.url == '/go-here-after-authenticating/'
 
 
-# @pytest.mark.django_db
-# @mock.patch('authbroker_client.views.get_client')
-# def test_callback_view_token_with_next_url(mocked_get_client, rf):
-#     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
-#     url = reverse('authbroker:callback')
-#     request = rf.get(url, {'code': 'foo', 'state': 'state'})
-#     request.user = AnonymousUser()
-#     request.session = StubSessionBackend({
-#         OAUTH_STATE_SESSION_KEY: 'state',
-#         REDIRECT_SESSION_FIELD_NAME: '/go-here-after-authenticating/',
-#     })
-#     response = AuthCallbackView.as_view()(request)
-#     assert response.status_code == 302
-#     assert response.url == '/go-here-after-authenticating/'
-
-
 @pytest.mark.django_db
 @mock.patch('authbroker_client.views.get_client')
 def test_callback_view_token_with_unsafe_next_url(mocked_get_client, rf):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -74,7 +74,7 @@ def test_callback_view_token(mocked_get_client, rf):
     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
     url = reverse('authbroker:callback')
     request = rf.get(url)
-    request.user = AnonymousUser
+    request.user = AnonymousUser()
     request.session = StubSessionBackend({f'{TOKEN_SESSION_KEY}_oauth_state': 'state'})
     request.GET = {'code': 'foo'}
     response = AuthCallbackView.as_view()(request)
@@ -88,7 +88,7 @@ def test_callback_view_token_with_next_url(mocked_get_client, rf):
     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
     url = reverse('authbroker:callback')
     request = rf.get(url)
-    request.user = AnonymousUser
+    request.user = AnonymousUser()
     request.session = StubSessionBackend({
         f'{TOKEN_SESSION_KEY}_oauth_state': 'state',
         REDIRECT_SESSION_FIELD_NAME: '/go-here-after-authenticating/'
@@ -99,13 +99,29 @@ def test_callback_view_token_with_next_url(mocked_get_client, rf):
     assert response.url == '/go-here-after-authenticating/'
 
 
+# @pytest.mark.django_db
+# @mock.patch('authbroker_client.views.get_client')
+# def test_callback_view_token_with_next_url(mocked_get_client, rf):
+#     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
+#     url = reverse('authbroker:callback')
+#     request = rf.get(url, {'code': 'foo', 'state': 'state'})
+#     request.user = AnonymousUser()
+#     request.session = StubSessionBackend({
+#         OAUTH_STATE_SESSION_KEY: 'state',
+#         REDIRECT_SESSION_FIELD_NAME: '/go-here-after-authenticating/',
+#     })
+#     response = AuthCallbackView.as_view()(request)
+#     assert response.status_code == 302
+#     assert response.url == '/go-here-after-authenticating/'
+
+
 @pytest.mark.django_db
 @mock.patch('authbroker_client.views.get_client')
 def test_callback_view_token_with_unsafe_next_url(mocked_get_client, rf):
     mocked_get_client.return_value.fetch_token.return_value = {'token': 'test'}
     url = reverse('authbroker:callback')
     request = rf.get(url)
-    request.user = AnonymousUser
+    request.user = AnonymousUser()
     request.session = StubSessionBackend({
         f'{TOKEN_SESSION_KEY}_oauth_state': 'state',
         REDIRECT_SESSION_FIELD_NAME: 'https://danger.com/'


### PR DESCRIPTION
# Description

AuthCallbackView throws an unhandled error when user isn't authenticated because `state_data` is accessed like a dict when in non-cache mode it will be a string. This PR adds a helper to address that issue and fixes tests that should've caught it.

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present