### PR TITLE
fix: Next URL lost from session on user login

### DIFF
--- a/authbroker_client/views.py
+++ b/authbroker_client/views.py
@@ -154,13 +154,13 @@ class AuthCallbackView(View):
                 "oauth callback: failed to retrieve access token", extra=meta
             )
 
+        next_url = get_next_url_from_state(request, state_data) or getattr(
+            settings, "LOGIN_REDIRECT_URL", "/"
+        )
         user = authenticate(request)
         if user is not None:
             login(request, user)
         else:
             logger.warning("oauth callback: authenticate() returned no user", extra=meta)
 
-        next_url = get_next_url_from_state(request, state_data) or getattr(
-            settings, "LOGIN_REDIRECT_URL", "/"
-        )
         return redirect(next_url)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -240,3 +240,63 @@ def test_cache_concurrent_flows_both_resolve(mocked_get_client, client, use_cach
 
     assert r1.url == '/a/'
     assert r2.url == '/b/'
+
+
+@pytest.mark.django_db
+@mock.patch("authbroker_client.views.authenticate")
+@mock.patch("authbroker_client.views.get_client")
+def test_callback_redirects_when_existing_session_for_different_backend_user(
+    mocked_get_client,
+    mocked_authenticate,
+    client,
+    django_user_model,
+    settings,
+):
+    settings.AUTHBROKER_USE_CACHE_STATE_STORE = False
+    settings.LOGIN_REDIRECT_URL = "/default/redirect/url"
+    settings.AUTHENTICATION_BACKENDS = [
+        "django.contrib.auth.backends.ModelBackend",
+        AUTHBROKER_BACKEND,
+    ]
+    existing_admin_user = django_user_model.objects.create_user(
+        username="admin@example.com",
+        email="admin@example.com",
+    )
+    sso_user = django_user_model.objects.create_user(
+        username="someone@example.com",
+        email="someone@example.com",
+    )
+    client.force_login(
+        existing_admin_user,
+        backend="django.contrib.auth.backends.ModelBackend",
+    )
+    # sanity check
+    assert client.session[BACKEND_SESSION_KEY] == "django.contrib.auth.backends.ModelBackend"
+    mocked_get_client.return_value.authorization_url.return_value = (
+        "https://sso.example.com/o/authorize/?state=state-A",
+        "state-A",
+    )
+    mocked_get_client.return_value.fetch_token.return_value = {"token": "test"}
+    sso_user.backend = AUTHBROKER_BACKEND
+    mocked_authenticate.return_value = sso_user
+
+    login_response = client.get(
+        reverse("authbroker:login"),
+        {"next": "/session/redirect/url"},
+    )
+
+    assert login_response.status_code == 302
+    assert client.session[REDIRECT_SESSION_FIELD_NAME] == "/session/redirect/url"
+
+    callback_response = client.get(
+        reverse("authbroker:callback"),
+        {
+            "code": "foo",
+            "state": "state-A",
+        },
+    )
+
+    assert callback_response.status_code == 302
+    assert callback_response.url == "/session/redirect/url"
+    assert callback_response.url != settings.LOGIN_REDIRECT_URL
+    assert client.session[BACKEND_SESSION_KEY] == AUTHBROKER_BACKEND


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

# Description

Current logic doesn't get `next` url from session when user isn't logged in, which means it always defaults to `settings.LOGIN_REDIRECT_URL`

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present