### PR TITLE
fix: remove unsupported type hint

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,21 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
         exclude:
+          # Django 5.0
+          - django-version: 5.0
+            python-version: 3.9
+          - django-version: 5.0
+            python-version: 3.13
+          - django-version: 5.0
+            python-version: 3.14
+          # Django 5.1
+          - django-version: 5.1
+            python-version: 3.9
+          - django-version: 5.1
+            python-version: 3.14
+          # Django 6.0
+          - django-version: 6.0
+            python-version: 3.9
           - django-version: 6.0
             python-version: 3.10
           - django-version: 6.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,9 @@ jobs:
             python-version: 3.9
           - django-version: 5.1
             python-version: 3.14
+          # Django 5.2
+          - django-version: 5.2
+            python-version: 3.9
           # Django 6.0
           - django-version: 6.0
             python-version: 3.9

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,8 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        django-version: ["5.2", "6.0"]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        django-version: ["4.2", "5.0", "5.1", "5.2", "6.0"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
         exclude:
           - django-version: 6.0

--- a/authbroker_client/version.py
+++ b/authbroker_client/version.py
@@ -1,2 +1,2 @@
 # The version of the package
-__version__ = "5.3.3"
+__version__ = "5.3.4"

--- a/authbroker_client/views.py
+++ b/authbroker_client/views.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict, Optional, Union
 
 from django.views.generic.base import RedirectView, View
 from django.shortcuts import redirect
@@ -54,7 +55,7 @@ def get_next_url(request):
 
 def get_next_url_from_state(
     request: HttpRequest,
-    state_data: dict[str, str | None] | str
+    state_data: Union[Dict[str, Optional[str]], str]
 ) -> str:
     if use_cache_state_store():
         return state_data.get("next_url")

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
     extras_require={
         'test': [
-            'pytest==9.0.3',
+            'pytest>=3.9',
             'pytest-cov',
             'pytest-django',
             'flake8==5.0.4',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
     extras_require={
         'test': [
-            'pytest>=3.9',
+            'pytest<9',
             'pytest-cov',
             'pytest-django',
             'flake8==5.0.4',

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,4 +3,4 @@ from authbroker_client.version import __version__
 
 def test_version():
     # Tests the version of the package
-    assert __version__ == "5.3.3"
+    assert __version__ == "5.3.4"


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

# Description

[PR70](https://github.com/uktrade/django-staff-sso-client/pull/70/changes) introduced type hinting unsupported by python 3.9

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present